### PR TITLE
Image info update

### DIFF
--- a/.github/workflows/auto_update.yml
+++ b/.github/workflows/auto_update.yml
@@ -1,0 +1,49 @@
+name: Update DB
+
+on: workflow_dispatch
+
+jobs:
+  update_db:
+    name: "Update DB"
+    runs-on: ubuntu-latest
+    env:
+      IMAGEBUILDER_BOT_GITLAB_SSH_KEY: ${{ secrets.IMAGEBUILDER_BOT_GITLAB_SSH_KEY }}
+      TRIGGER_TOKEN: ${{ secrets.TRIGGER_TOKEN }}
+    steps:
+      - name: Clone composer
+        uses: actions/checkout@v3
+        with:
+          repository: osbuild/osbuild-composer
+          path: composer
+
+      - name: Checkout manifest-db
+        uses: actions/checkout@v3
+        with:
+          path: manifest-db
+          fetch-depth: 0
+
+      - name: Update DB
+        run: |
+          ./manifest-db/tools/import-image-tests composer/test/data/manifests/ manifest-db/manifest-db --manifest-only --db-ignore=manifest-db/db-ignore --verbose
+
+      - name: Send to CI
+        run: |
+          cd manifest-db
+          git config --local user.name "SchutzBot"
+          git config --local user.email "imagebuilder-bots+schutzbot@redhat.com"
+
+          now=$(date '+%Y-%m-%d-%H%M%S')
+          BRANCH_NAME="db-update-$now"
+          git checkout -b "$BRANCH_NAME"
+          git add -A
+          git commit -m "db: automatic update of manifests."
+
+          mkdir -p ~/.ssh
+          echo "${IMAGEBUILDER_BOT_GITLAB_SSH_KEY}" > ~/.ssh/id_rsa
+          chmod 400 ~/.ssh/id_rsa
+          touch ~/.ssh/known_hosts
+          ssh-keyscan -t rsa gitlab.com >> ~/.ssh/known_hosts
+          git remote add ci git@gitlab.com:redhat/services/products/image-builder/ci/manifest-db.git
+          git push -f ci -o ci.skip
+
+          curl --request POST --form token=$TRIGGER_TOKEN --form ref=$BRANCH_NAME https://gitlab.com/api/v4/projects/36844106/trigger/pipeline

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -42,6 +42,8 @@ Regression:
     - schutzbot/deploy.sh
     - sudo schutzbot/selinux-context.sh
     - sudo test/cases/regression_tests
+  rules:
+    - if: '$CI_PIPELINE_SOURCE != "trigger"'
   artifacts:
     when: always
     paths:
@@ -58,6 +60,8 @@ Manifests:
     - schutzbot/deploy.sh
     - sudo schutzbot/selinux-context.sh
     - sudo test/cases/manifest_tests
+  rules:
+    - if: '$CI_PIPELINE_SOURCE == "trigger"'
   artifacts:
     when: always
     paths:
@@ -80,8 +84,23 @@ Manifests:
           - aws/rhel-9.0-ga-aarch64
         INTERNAL_NETWORK: "true"
 
+push-image-info:
+  stage: finish
+  extends: .terraform
+  script:
+    - schutzbot/deploy.sh
+    - schutzbot/include_image_info.sh
+  rules:
+    - if: '$CI_PIPELINE_SOURCE == "trigger"'
+  parallel:
+    matrix:
+      - RUNNER:
+          - aws/fedora-35-x86_64
+
 finish:
   stage: finish
+  rules:
+    - if: '$CI_PIPELINE_SOURCE != "trigger"'
   dependencies: []
   tags:
     - shell

--- a/README.md
+++ b/README.md
@@ -1,0 +1,29 @@
+Manifest-db
+=======
+
+Stores all the manifests and corresponding image-infos to test OSbuild.
+
+### Update workflow
+
+The update workflow starts with a github action that is manually triggered. This
+GH action is named `Update DB`. It will firstly clone the latest
+`osbuild-composer` and copy all its manifests into the database. Secondly the
+action will create a commit and push this on the corresponding gitlab ci
+project
+(https://gitlab.com/redhat/services/products/image-builder/ci/manifest-db).
+Thirdly, after the push is completed, the action triggers a special pipeline on
+the CI. This pipeline builds every manifest from the DB. Once building is done,
+the pipeline starts the `schutzbot/include_image_info.sh` script. This script
+will download all the produced image-infos resulting from the builds and update
+the DB with them. Then it will amend the commit sent to the CI pipeline with
+these freshly built image-info, push this commit to github on a branch and
+create a pull request out of it.
+
+### Contributing
+
+Please refer to the [developer guide](https://www.osbuild.org/guides/developer-guide/developer-guide.html) to learn about our workflow, code style and more.
+
+### License:
+
+ - **Apache-2.0**
+ - See LICENSE file for details.

--- a/db-ignore
+++ b/db-ignore
@@ -1,0 +1,10 @@
+centos_8-x86_64-image_installer-boot
+centos_8-x86_64-image_installer_with_users-boot
+centos_9-x86_64-image_installer-boot
+centos_9-x86_64-image_installer_with_users-boot
+rhel_85-x86_64-image_installer-boot
+rhel_85-x86_64-image_installer_with_users-boot
+rhel_86-x86_64-image_installer-boot
+rhel_86-x86_64-image_installer_with_users-boot
+rhel_90-x86_64-image_installer-boot
+rhel_90-x86_64-image_installer_with_users-boot

--- a/schutzbot/include_image_info.sh
+++ b/schutzbot/include_image_info.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+set -euxo pipefail
+sudo dnf install gh -y pip python3-gitlab
+
+# Login to GH
+echo "${SCHUTZBOT_GH_TOKEN}" | gh auth login --with-token
+
+# import the image info from the current build
+./tools/ci_import --pipeline-id "$CI_PIPELINE_ID" --token "${GITLAB_TOKEN}"
+
+#remove ci-details-before-run
+mv ci-details-before-run /tmp
+rm -rf generated-image-infos
+
+# Amend the commit containing the db update
+git checkout "$CI_COMMIT_BRANCH"
+
+git config --local user.name "SchutzBot"
+git config --local user.email "imagebuilder-bots+schutzbot@redhat.com"
+
+git remote add upstream https://schutzbot:"$SCHUTZBOT_GH_TOKEN"@github.com/schutzbot/manifest-db.git
+
+git add -A && \
+    git commit --amend -m "db: update
+
+Automatic update:
+- manifests from latest composer
+- image-info from pipeline $CI_PIPELINE_ID" && \
+    git push --set-upstream upstream "$CI_COMMIT_BRANCH" && \
+    gh pr create \
+        --title "db update" \
+        --body "automated db update" \
+        --repo "osbuild/manifest-db" \
+        -r lavocatt
+
+#restore ci-details-before-run
+mv /tmp/ci-details-before-run .

--- a/tools/ci_import
+++ b/tools/ci_import
@@ -1,0 +1,122 @@
+#!/bin/env python
+
+import argparse
+import json
+import os
+import sys
+import zipfile
+import tempfile
+from os import path
+
+import gitlab
+
+IMI_DIRECTORY = "generated-image-infos"
+MANIFEST_DB_PROJECT_ID = 36844106
+
+
+def list_jobs(pipeline, token):
+    """
+    Connects to the gitlab API and retrives the list of the jobs contained in a
+    given pipeline.
+    """
+    gl = gitlab.Gitlab("https://gitlab.com", oauth_token=token)
+    project = gl.projects.get(MANIFEST_DB_PROJECT_ID)
+    pipeline = project.pipelines.get(pipeline)
+    return pipeline.jobs.list(all=True), project
+
+
+def get_job_dir(tempdir, job):
+    """
+    Returns a directory where to store a job's artifacts
+    """
+    directory = path.join(tempdir, str(job.get_id()))
+    os.makedirs(directory, exist_ok=True)
+    return directory
+
+
+def download_artifacts(directory, project, job):
+    """
+    Download an artificact.zip if available for a given job and extract it.
+    Can raise an exception if no artifacts are available.
+    """
+    filename = os.path.join(directory, "artifact.zip")
+    with open(filename, "wb") as f:
+        project.jobs.get(job.get_id()).artifacts(streamed=True, action=f.write)
+    z = zipfile.ZipFile(filename)
+    z.extractall(directory)
+    print(f"    downloading artifact.zip to {filename} for job {job.get_id()}")
+
+
+def download_image_infos(job_dir, project, job):
+    """
+    Downloads the image info and return their path as a list
+    """
+    try:
+        download_artifacts(job_dir, project, job)
+    except gitlab.exceptions.GitlabGetError as e:
+        print(f"    {e} ⚠️")
+        return []
+    image_info_directory = os.path.join(job_dir, IMI_DIRECTORY)
+    try:
+        image_infos = os.listdir(image_info_directory)
+        print(f"    image information imported for {job.get_id()}")
+        return [os.path.join(image_info_directory, image_info) for image_info in image_infos]
+    except FileNotFoundError:
+        print(f"    no image information for {job.get_id()}")
+        return []
+
+
+def update_db(image_info_path):
+    """
+    Take a downloaded image info and write its content into the corresponding
+    test case in the database.
+    """
+    image_info = os.path.basename(image_info_path)
+    print(f"    {image_info}:", end=" ")
+    # load the image info content
+    with open(image_info_path, "r", encoding="utf-8") as f:
+        image_info_data = json.load(f)
+    # load test case
+    test_case_path = os.path.join("manifest-db", image_info)
+    with open(test_case_path, "r", encoding="utf-8") as f:
+        tc_data = json.load(f)
+    # update test case
+    print(f"updating {test_case_path}:", end=" ")
+    tc_data["image-info"] = image_info_data
+    with open(test_case_path, "w", encoding="utf-8") as f:
+        json.dump(tc_data, f, indent=2)
+    print("✅")
+
+
+def import_image_infos(tempdir, pipeline, token):
+    """
+    Imports the image info from a pipeline into the database.
+    """
+    jobs, project = list_jobs(pipeline, token)
+    for job in jobs:
+        print(f"Job {job.get_id()}:")
+        # for each downloaded image info, update the test cases
+        for image_info_path in download_image_infos(get_job_dir(tempdir, job), project, job):
+            update_db(image_info_path)
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Import image-info from ci jobs")
+    parser.add_argument(
+        "--pipeline-id",
+        required=True,
+        help="Id of the pipeline on gitlab"
+    )
+    parser.add_argument(
+        "--token",
+        required=True,
+        help="gitlab token"
+    )
+
+    args = parser.parse_args()
+    with tempfile.TemporaryDirectory() as tempdir:
+        import_image_infos(tempdir, args.pipeline_id, args.token)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/import-image-tests
+++ b/tools/import-image-tests
@@ -66,7 +66,7 @@ def load_test(name, fullpath) -> dict:
 def export_test(test, target, manifest_only):
     name = test["id"]
     fullpath = os.path.join(target, name + ".json")
-    if  manifest_only and os.path.exists(fullpath):
+    if manifest_only and os.path.exists(fullpath):
         # load existing
         with open(fullpath, "r", encoding="utf-8") as f:
             base = json.load(f)

--- a/tools/import-image-tests
+++ b/tools/import-image-tests
@@ -63,9 +63,16 @@ def load_test(name, fullpath) -> dict:
     return test
 
 
-def export_test(test, target):
+def export_test(test, target, manifest_only):
     name = test["id"]
     fullpath = os.path.join(target, name + ".json")
+    if  manifest_only and os.path.exists(fullpath):
+        # load existing
+        with open(fullpath, "r", encoding="utf-8") as f:
+            base = json.load(f)
+        # only replace the manifest in the base
+        base["manifest"] = test["manifest"]
+        test = base
     with open(fullpath, "w", encoding="utf-8") as f:
         json.dump(test, f, indent=2)
 
@@ -109,6 +116,12 @@ def main():
         default=False,
         help="do not export test cases"
     )
+    parser.add_argument(
+        "--manifest-only",
+        action="store_true",
+        default=False,
+        help="Only import the manifests from composer"
+    )
     group = parser.add_mutually_exclusive_group()
     group.add_argument(
         "--verbose",
@@ -134,7 +147,7 @@ def main():
             if args.dry_run:
                 continue
 
-            export_test(test, args.TARGET)
+            export_test(test, args.TARGET, args.manifest_only)
         except ValueError as e:
             report_failure(name, str(e), args.verbosity)
             failures.append(name)

--- a/tools/import-image-tests
+++ b/tools/import-image-tests
@@ -135,13 +135,26 @@ def main():
         const=0,
         dest="verbosity",
         help="suppress output")
+    parser.add_argument(
+        "--db-ignore",
+        type=os.path.abspath,
+        default=None,
+        help="A file containing one per line file names not to import")
 
     args = parser.parse_args()
+
+    db_ignore = []
+    if args.db_ignore:
+        with open(args.db_ignore, "r", encoding="utf-8") as f:
+            db_ignore = f.read().splitlines()
 
     idx = 0
     failures = []
     for idx, (name, path) in enumerate(list_tests(args.SOURCE)):
         try:
+            if name in db_ignore:
+                continue
+
             test = load_test(name, path)
 
             if args.dry_run:

--- a/tools/osbuild-image-test
+++ b/tools/osbuild-image-test
@@ -278,7 +278,38 @@ class TestCase:
         return True
 
     def compare(self):
-        if self.built_image_info != self.desired_image_info:
+        def filter_fn(imi):
+            """
+            Filter specific fields in the image-info that can't be compared
+            together.
+            """
+            def lvm2(imi):
+                """
+                LVM2 partitions have a UUID that is not fixed. Replace the value
+                upon comparison time
+                """
+                partitions = imi.get("partitions")
+                if partitions:
+                    for partition in partitions:
+                        if partition.get("fstype") == "LVM2_member":
+                            partition["uuid"] = "2022-07-01-fixed-uuid"
+                return imi
+
+            def iso(imi):
+                """
+                For isos, the partition UUID is the date of the build. Replace
+                that with a fixed one for the comparison.
+                """
+                if "image-format" in imi and "type" in imi["image-format"] and imi["image-format"]["type"] == "raw":
+                    if "partitions" in imi:
+                        for partition in imi["partitions"]:
+                            if "fstype" in partition:
+                                if partition["fstype"] == "iso9660":
+                                    partition["uuid"] = "2022-07-01-fixed-uuid"
+                return imi
+            return iso(lvm2(imi))
+
+        if filter_fn(self.built_image_info) != filter_fn(self.desired_image_info):
             self.error = "image-info mismatch"
             return False
         return True


### PR DESCRIPTION
Add a framework to update the image-info in the repository.
This PR brings several tools to do the task:

* The first one is `ci_import` is used to import genereated image-info from a pipeline job in the CI
* The second one is a github action that can be trigger to import the manifests from the last composer version, this action is manually triggered and will create a PR containing a single commit hosting the changes to the manifests.
* The third and last one is a github action that is triggered for each new PR. It will call the `ci_import` tool after `Schutzbot` has successfully run. If new image-info are produced, or if they are updated, then a new commit will land on top of PR with these modifications.

Due to the properties of the gthub actions, the manual trigger could not be tested here, however, it runs on this ci job:
https://gitlab.com/redhat/services/products/image-builder/ci/manifest-db/-/pipelines/610538989