### PR TITLE
Fix the SELinux mismatch

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -40,7 +40,7 @@ Regression:
   extends: .terraform
   script:
     - schutzbot/deploy.sh
-    - sudo schutzbot/selinux-context.sh
+    - schutzbot/selinux-context.sh
     - sudo test/cases/regression_tests
   rules:
     - if: '$CI_PIPELINE_SOURCE != "trigger"'
@@ -58,7 +58,7 @@ Manifests:
   extends: .terraform
   script:
     - schutzbot/deploy.sh
-    - sudo schutzbot/selinux-context.sh
+    - schutzbot/selinux-context.sh
     - sudo test/cases/manifest_tests
   rules:
     - if: '$CI_PIPELINE_SOURCE == "trigger"'

--- a/Schutzfile
+++ b/Schutzfile
@@ -1,10 +1,12 @@
 {
-  "fedora-35": {
+  "global": {
     "dependencies": {
       "osbuild": {
-        "commit": "07d36053854ac2d678a6f2a7424338d082913e46"
+        "commit": "b87eaf603284681335704910636123778dd57895"
       }
-    },
+    }
+  },
+  "fedora-35": {
     "repos": [
       {
         "file": "/etc/yum.repos.d/fedora.repo",
@@ -77,11 +79,6 @@
     ]
   },
   "fedora-36": {
-    "dependencies": {
-      "osbuild": {
-        "commit": "07d36053854ac2d678a6f2a7424338d082913e46"
-      }
-    },
     "repos": [
       {
         "file": "/etc/yum.repos.d/fedora.repo",
@@ -154,11 +151,6 @@
     ]
   },
   "rhel-8.6": {
-    "dependencies": {
-      "osbuild": {
-        "commit": "07d36053854ac2d678a6f2a7424338d082913e46"
-      }
-    },
     "repos": [
       {
         "file": "/etc/yum.repos.d/rhel8internal.repo",
@@ -200,11 +192,6 @@
     ]
   },
   "rhel-8.7": {
-    "dependencies": {
-      "osbuild": {
-        "commit": "07d36053854ac2d678a6f2a7424338d082913e46"
-      }
-    },
     "repos": [
       {
         "file": "/etc/yum.repos.d/rhel8internal.repo",
@@ -246,11 +233,6 @@
     ]
   },
   "rhel-9.0": {
-    "dependencies": {
-      "osbuild": {
-        "commit": "07d36053854ac2d678a6f2a7424338d082913e46"
-      }
-    },
     "repos": [
       {
         "file": "/etc/yum.repos.d/rhel9internal.repo",
@@ -292,11 +274,6 @@
     ]
   },
   "rhel-9.1": {
-    "dependencies": {
-      "osbuild": {
-        "commit": "07d36053854ac2d678a6f2a7424338d082913e46"
-      }
-    },
     "repos": [
       {
         "file": "/etc/yum.repos.d/rhel9internal.repo",
@@ -338,11 +315,6 @@
     ]
   },
   "centos-stream-9": {
-    "dependencies": {
-      "osbuild": {
-        "commit": "07d36053854ac2d678a6f2a7424338d082913e46"
-      }
-    },
     "repos": [
       {
         "file": "/etc/yum.repos.d/centos.repo",
@@ -384,11 +356,6 @@
     ]
   },
   "centos-stream-8": {
-      "dependencies": {
-        "osbuild": {
-          "commit": "07d36053854ac2d678a6f2a7424338d082913e46"
-        }
-      },
     "repos": [
       {
         "file": "/etc/yum.repos.d/CentOS-Stream-BaseOS.repo",

--- a/schutzbot/deploy.sh
+++ b/schutzbot/deploy.sh
@@ -1,56 +1,22 @@
 #!/bin/bash
 set -euxo pipefail
 
-# set locale to en_US.UTF-8
-sudo dnf install -y glibc-langpack-en git make jq
-localectl set-locale LANG=en_US.UTF-8
+sudo dnf install -y jq
 
-# Colorful output.
-function greenprint {
-    echo -e "\033[1;32m[$(date -Isecond)] ${1}\033[0m"
-}
 
-function setup_repo {
-  local project=$1
-  local commit=$2
-  local priority=${3:-10}
+DNF_REPO_BASEURL=http://osbuild-composer-repos.s3.amazonaws.com
 
-  local REPO_PATH=${project}/${DISTRO_VERSION}/${ARCH}/${commit}
-  if [[ "${NIGHTLY:=false}" == "true" && "${project}" == "osbuild-composer" ]]; then
-    REPO_PATH=nightly/${REPO_PATH}
-  fi
-
-  greenprint "Setting up dnf repository for ${project} ${commit}"
-  sudo tee "/etc/yum.repos.d/${project}.repo" << EOF
-[${project}]
-name=${project} ${commit}
-baseurl=http://osbuild-composer-repos.s3-website.us-east-2.amazonaws.com/${REPO_PATH}
-enabled=1
-gpgcheck=0
-priority=${priority}
-EOF
-}
+# The osbuild-composer commit to run reverse-dependency test against.
+# Currently: CI: temporarily switch RHOS-01 to non-ssd instances
+OSBUILD_COMPOSER_COMMIT=de72b36dddfc703d76d79479dde7b92f0a78e924
+OSBUILD_COMMIT=$(jq -r '.global.dependencies.osbuild.commit' Schutzfile)
 
 # Get OS details.
 source /etc/os-release
 ARCH=$(uname -m)
-DISTRO_CODE="${DISTRO_CODE:-${ID}-${VERSION_ID//./}}"
 
-if [[ $ID == "rhel" && ${VERSION_ID%.*} == "9" ]]; then
-  # There's a bug in RHEL 9 that causes /tmp to be mounted on tmpfs.
-  # Explicitly stop and mask the mount unit to prevent this.
-  # Otherwise, the tests will randomly fail because we use /tmp quite a lot.
-  # See https://bugzilla.redhat.com/show_bug.cgi?id=1959826
-  greenprint "Disabling /tmp as tmpfs on RHEL 9"
-  sudo systemctl stop tmp.mount && sudo systemctl mask tmp.mount
-fi
-
-if [[ $ID == "centos" && $VERSION_ID == "8" ]]; then
-    # Workaround for https://bugzilla.redhat.com/show_bug.cgi?id=2065292
-    # Remove when podman-4.0.2-2.el8 is in Centos 8 repositories
-    greenprint "Updating libseccomp on Centos 8"
-    sudo dnf upgrade -y libseccomp
-fi
+# Add osbuild team ssh keys.
+cat schutzbot/team_ssh_keys.txt | tee -a ~/.ssh/authorized_keys > /dev/null
 
 # Distro version that this script is running on.
 DISTRO_VERSION=${ID}-${VERSION_ID}
@@ -59,20 +25,38 @@ if [[ "$ID" == rhel ]] && sudo subscription-manager status; then
   # If this script runs on subscribed RHEL, install content built using CDN
   # repositories.
   DISTRO_VERSION=rhel-${VERSION_ID%.*}-cdn
-
-  # workaround for https://github.com/osbuild/osbuild/issues/717
-  sudo subscription-manager config --rhsm.manage_repos=1
 fi
 
-greenprint "Enabling fastestmirror to speed up dnf 🏎️"
-echo -e "fastestmirror=1" | sudo tee -a /etc/dnf/dnf.conf
+# Set up dnf repositories with the RPMs we want to test
+sudo tee /etc/yum.repos.d/osbuild.repo << EOF
+[osbuild]
+name=osbuild ${CI_COMMIT_SHA}
+baseurl=${DNF_REPO_BASEURL}/osbuild/${DISTRO_VERSION}/${ARCH}/${OSBUILD_COMMIT}
+enabled=1
+gpgcheck=0
+# Default dnf repo priority is 99. Lower number means higher priority.
+priority=5
 
-OSBUILD_GIT_COMMIT=$(cat Schutzfile | jq -r '.global.dependencies.osbuild.commit')
-if [[ "${OSBUILD_GIT_COMMIT}" != "null" ]]; then
-  setup_repo osbuild "${OSBUILD_GIT_COMMIT}" 10
+[osbuild-composer]
+name=osbuild-composer ${OSBUILD_COMPOSER_COMMIT}
+baseurl=${DNF_REPO_BASEURL}/osbuild-composer/${DISTRO_VERSION}/${ARCH}/${OSBUILD_COMPOSER_COMMIT}
+enabled=1
+gpgcheck=0
+# Give this a slightly lower priority, because we used to have osbuild in this repo as well.
+priority=10
+EOF
+
+if [[ $ID == rhel || $ID == centos ]] && ! rpm -q epel-release; then
+    # Set up EPEL repository (for ansible and koji)
+    sudo dnf install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-${VERSION_ID%.*}.noarch.rpm
 fi
 
-sudo dnf install -y osbuild* python3-pip container-selinux
-pip3 show osbuild
+# Install the Image Builder packages.
+# Note: installing only -tests to catch missing dependencies
+sudo dnf -y install osbuild-composer-tests
 
-greenprint "OSBuild installed"
+# Set up a directory to hold repository overrides.
+sudo mkdir -p /etc/osbuild-composer/repositories
+
+# Temp fix until composer gains these dependencies
+sudo dnf -y install osbuild-luks2 osbuild-lvm2

--- a/schutzbot/deploy.sh
+++ b/schutzbot/deploy.sh
@@ -35,7 +35,6 @@ EOF
 source /etc/os-release
 ARCH=$(uname -m)
 DISTRO_CODE="${DISTRO_CODE:-${ID}-${VERSION_ID//./}}"
-OSBUILD_GIT_COMMIT=$(cat Schutzfile | jq -r '.["'"${ID}-${VERSION_ID}"'"].dependencies.osbuild.commit')
 
 if [[ $ID == "rhel" && ${VERSION_ID%.*} == "9" ]]; then
   # There's a bug in RHEL 9 that causes /tmp to be mounted on tmpfs.
@@ -68,14 +67,12 @@ fi
 greenprint "Enabling fastestmirror to speed up dnf 🏎️"
 echo -e "fastestmirror=1" | sudo tee -a /etc/dnf/dnf.conf
 
-OSBUILD_GIT_COMMIT=$(cat Schutzfile | jq -r '.["'"${ID}-${VERSION_ID}"'"].dependencies.osbuild.commit')
+OSBUILD_GIT_COMMIT=$(cat Schutzfile | jq -r '.global.dependencies.osbuild.commit')
 if [[ "${OSBUILD_GIT_COMMIT}" != "null" ]]; then
   setup_repo osbuild "${OSBUILD_GIT_COMMIT}" 10
 fi
 
-sudo dnf install -y osbuild*
-
-sudo dnf install -y python3-pip
+sudo dnf install -y osbuild* python3-pip container-selinux
 pip3 show osbuild
 
 greenprint "OSBuild installed"

--- a/schutzbot/selinux-context.sh
+++ b/schutzbot/selinux-context.sh
@@ -1,3 +1,3 @@
-OSBUILD_LABEL=$(matchpathcon -n $(which osbuild))
+set -euxo pipefail
+OSBUILD_LABEL=$(matchpathcon -n /usr/bin/osbuild)
 chcon $OSBUILD_LABEL tools/image-info
-chcon $OSBUILD_LABEL tools/osbuild-image-test


### PR DESCRIPTION
The issues are: 
* I have missing packages in my setup and that leads to SELinux mismatch between what I'm computing on this CI and OSBuild's CI.
* The `which` command used alongside `matchpathcon` does not give the same result when its called from root or user context. And therefore we don't have access to the proper label for the `image-info` command.

The first issue is fixed by by copying the `deploy.sh` setup procedure from `OSBuild`.
The second issue is fixed by specifying the path to access the `osbuild` executable when calling `matchpathcon`. 

Now `deploy.sh` uses the composer-tests package to have the base configuration even though we are not using the tests coming from this package. A probable next step would be to create it's own package definition for manifest-db and to install it the way we are installing composer-tests package.