### PR TITLE
db-update: generate manifests build image-info and propagate to OSBuild

### DIFF
--- a/.github/workflows/auto_update.yml
+++ b/.github/workflows/auto_update.yml
@@ -10,23 +10,13 @@ jobs:
       IMAGEBUILDER_BOT_GITLAB_SSH_KEY: ${{ secrets.IMAGEBUILDER_BOT_GITLAB_SSH_KEY }}
       TRIGGER_TOKEN: ${{ secrets.TRIGGER_TOKEN }}
     steps:
-      - name: Clone composer
-        uses: actions/checkout@v3
-        with:
-          repository: osbuild/osbuild-composer
-          path: composer
-
       - name: Checkout manifest-db
         uses: actions/checkout@v3
         with:
           path: manifest-db
           fetch-depth: 0
 
-      - name: Update DB
-        run: |
-          ./manifest-db/tools/import-image-tests composer/test/data/manifests/ manifest-db/manifest-db --manifest-only --db-ignore=manifest-db/db-ignore --filter-with-ci-distros=manifest-db/.gitlab-ci.yml --verbose
-
-      - name: Send to CI
+      - name: trigger CI
         run: |
           cd manifest-db
           git config --local user.name "SchutzBot"
@@ -35,8 +25,6 @@ jobs:
           now=$(date '+%Y-%m-%d-%H%M%S')
           BRANCH_NAME="db-update-$now"
           git checkout -b "$BRANCH_NAME"
-          git add -A
-          git commit -m "db: automatic update of manifests."
 
           mkdir -p ~/.ssh
           echo "${IMAGEBUILDER_BOT_GITLAB_SSH_KEY}" > ~/.ssh/id_rsa

--- a/.github/workflows/auto_update.yml
+++ b/.github/workflows/auto_update.yml
@@ -1,6 +1,8 @@
 name: Update DB
 
-on: workflow_dispatch
+on:
+  schedule:
+    - cron: '0 0 1,15 * *' # 1st and 15th of every month
 
 jobs:
   update_db:

--- a/.github/workflows/auto_update.yml
+++ b/.github/workflows/auto_update.yml
@@ -7,31 +7,8 @@ jobs:
     name: "Update DB"
     runs-on: ubuntu-latest
     env:
-      IMAGEBUILDER_BOT_GITLAB_SSH_KEY: ${{ secrets.IMAGEBUILDER_BOT_GITLAB_SSH_KEY }}
       TRIGGER_TOKEN: ${{ secrets.TRIGGER_TOKEN }}
     steps:
-      - name: Checkout manifest-db
-        uses: actions/checkout@v3
-        with:
-          path: manifest-db
-          fetch-depth: 0
-
-      - name: trigger CI
+      - name: Trigger CI
         run: |
-          cd manifest-db
-          git config --local user.name "SchutzBot"
-          git config --local user.email "imagebuilder-bots+schutzbot@redhat.com"
-
-          now=$(date '+%Y-%m-%d-%H%M%S')
-          BRANCH_NAME="db-update-$now"
-          git checkout -b "$BRANCH_NAME"
-
-          mkdir -p ~/.ssh
-          echo "${IMAGEBUILDER_BOT_GITLAB_SSH_KEY}" > ~/.ssh/id_rsa
-          chmod 400 ~/.ssh/id_rsa
-          touch ~/.ssh/known_hosts
-          ssh-keyscan -t rsa gitlab.com >> ~/.ssh/known_hosts
-          git remote add ci git@gitlab.com:redhat/services/products/image-builder/ci/manifest-db.git
-          git push -f ci -o ci.skip
-
-          curl --request POST --form token=$TRIGGER_TOKEN --form ref=$BRANCH_NAME https://gitlab.com/api/v4/projects/36844106/trigger/pipeline
+          curl --request POST --form token=$TRIGGER_TOKEN --form ref=main https://gitlab.com/api/v4/projects/36844106/trigger/pipeline

--- a/.github/workflows/propagate_to_osbuild.yml
+++ b/.github/workflows/propagate_to_osbuild.yml
@@ -1,0 +1,70 @@
+name: Propagate update to OSBuild
+
+on: workflow_dispatch
+
+jobs:
+  propagate:
+    runs-on: ubuntu-latest
+    env:
+      SCHUTZBOT_GH: ${{ secrets.SCHUTZBOT_GH }}
+    steps:
+      - name: Checkout manifest-db
+        uses: actions/checkout@v3
+        with:
+          path: manifest-db
+          fetch-depth: 0
+
+      - name: Update OSBuild
+        run: |
+          # Get the manifest-db HEAD
+          MANIFEST_DB_HEAD="${{ github.sha }}"
+          echo "manifest-db head: $MANIFEST_DB_HEAD"
+
+          # get the old ref from the OSBuild's Schutzfile
+          git clone https://github.com/osbuild/osbuild.git
+          cd osbuild
+          OLD_REF=$(jq -r '.global.dependencies."manifest-db".commit' Schutzfile)
+          echo "manifest-db version in OSBuild: $MANIFEST_DB_HEAD"
+
+          # update only if the DB was updated since the version OSBuild is
+          # using
+          cd ../manifest-db
+          if git diff --quiet $MANIFEST_DB_HEAD $OLD_REF manifest-db; then
+            echo "The DB was not updated since $OLD_REF, ignoring"
+            exit 0
+          fi
+
+          # Generate the commit list to integrate in the PR
+          COMMIT_LIST=$(git log --oneline $OLD_REF..$MANIFEST_DB_HEAD | sed 's/.*/- https:\/\/github.com\/osbuild\/manifest-db\/commit\/&/')
+
+          # login as schutzbot
+          cd ../osbuild
+          echo "${SCHUTZBOT_GH}" | gh auth login --with-token
+          git config --local user.name "SchutzBot"
+          git config --local user.email "imagebuilder-bots+schutzbot@redhat.com"
+
+          # Create a branch for the PR
+          now=$(date '+%Y-%m-%d-%H%M%S')
+          BRANCH_NAME="manifest-db-update-$now"
+          git checkout -b $BRANCH_NAME
+
+          # change the value for the commit head in the schutzfile
+          jq --arg variable "$MANIFEST_DB_HEAD" '.global.dependencies."manifest-db".commit=$variable' Schutzfile > Schutzfile.tmp && mv Schutzfile.tmp Schutzfile
+
+          # create the PR
+          PR_BODY="$(cat <<-END
+          This PR updates the manifest-db ref dependency for OSBuild. Between the
+          last time it was updated, and this new reference commit, these are the changes:
+
+          $COMMIT_LIST
+          END
+          )"
+          git remote add upstream https://schutzbot:"$SCHUTZBOT_GH"@github.com/schutzbot/osbuild.git
+          git add -A && \
+              git commit -m "schutzfile: update manifest-db ref $(date '+%Y-%m-%d')" && \
+              git push upstream "$BRANCH_NAME:$BRANCH_NAME" && \
+              gh pr create \
+                  --title "schutzfile: update manifest-db ref $(date '+%Y-%m-%d')" \
+                  --body "$PR_BODY" \
+                  --repo "osbuild/osbuild" \
+                  -r lavocatt

--- a/.github/workflows/propagate_to_osbuild.yml
+++ b/.github/workflows/propagate_to_osbuild.yml
@@ -1,6 +1,8 @@
 name: Propagate update to OSBuild
 
-on: workflow_dispatch
+on:
+  schedule:
+    - cron: '0 0 5,20 * *' # 5th and 20th of every month
 
 jobs:
   propagate:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,6 +1,8 @@
 stages:
   - init
+  - gen
   - test
+  - build
   - finish
 
 .base:
@@ -53,12 +55,30 @@ Regression:
       - RUNNER:
           - aws/fedora-35-x86_64
 
-Manifests:
-  stage: test
+Manifest-gen:
+  stage: gen
+  extends: .terraform
+  rules:
+    - if: '$CI_PIPELINE_SOURCE == "trigger"'
+  artifacts:
+    when: always
+    paths:
+      - manifests
+  script:
+    - schutzbot/gen_manifests.sh
+  parallel:
+    matrix:
+      - RUNNER:
+          - aws/rhel-9.0-ga-x86_64
+        INTERNAL_NETWORK: "true"
+
+Image-info-build:
+  stage: build
   extends: .terraform
   script:
     - schutzbot/deploy.sh
     - schutzbot/selinux-context.sh
+    - tools/import-image-tests manifests manifest-db --manifest-only --db-ignore=db-ignore --filter-with-ci-distros=.gitlab-ci.yml --verbose
     - sudo test/cases/manifest_tests
   rules:
     - if: '$CI_PIPELINE_SOURCE == "trigger"'
@@ -66,6 +86,8 @@ Manifests:
     when: always
     paths:
       - generated-image-infos/
+  dependencies:
+    - Manifest-gen
   parallel:
     matrix:
       - RUNNER:
@@ -92,8 +114,11 @@ push-image-info:
   stage: finish
   extends: .terraform
   script:
-    - schutzbot/deploy.sh
+    - tools/import-image-tests manifests manifest-db --manifest-only --db-ignore=db-ignore --filter-with-ci-distros=.gitlab-ci.yml --verbose
+    - rm -r manifests
     - schutzbot/include_image_info.sh
+  dependencies:
+    - Manifest-gen
   rules:
     - if: '$CI_PIPELINE_SOURCE == "trigger"'
   parallel:

--- a/README.md
+++ b/README.md
@@ -5,37 +5,38 @@ Stores all the manifests and corresponding image-infos to test OSbuild.
 
 ### Update workflow
 
-The update workflow is made of 3 distinct steps:
+#### 1/ on GitHub: trigger the Gitlab CI
 
-#### First step, triggering the CI
-
-The update workflow starts with an `Update DB` GitHub action that is manually
-triggered. This action imports a subset of the manifests from osbuild-composer,
-specifically those CI is able to build.
-
-Importing manifests which cannot be built by CI will leave the
-DB in a dirty state. For this reason they are excluded.
-
-Once the import is done, a commit is created and pushed to [this GitLab repository](https://gitlab.com/redhat/services/products/image-builder/ci/manifest-db).
-
-#### Second step, running the CI
 
 Using a GitLab `trigger token` the GitHub action starts the CI with a
 different workflow than the one used to run the regression testing.
 
-A job for each architecture and distribution listed in
+#### 2/ on CI: Manifest generation
+
+The first job downloads the latest osbuild-composer sources from upstream,
+generates all test manifests using the gen-manifest tool and stores them as an
+artifact.
+
+#### 3/ on CI: Image-info builds
+
+Then a job for each architecture and distribution listed in
 [.gitlab-ci.yml](https://github.com/osbuild/manifest-db/blob/main/.gitlab-ci.yml)
-will run in parallel. Each job will generate and include the image-info for the
-manifests where possible and expose them as artifacts. As a final step, a
-conclusion job downloads every artifact and includes it in the commit that
-initially triggered the CI job.
+will run in parallel. Each job will:
 
-#### Third step, opening a PR on GitHub
+- import the generated manifests.
+- generate and include the image-info for the manifests where possible and
+  expose them as artifacts.
 
-Finally the commit is pushed to GitHub by Schutzbot and a PR is opened.
+#### 4/ on CI: PR creation
+
+Finally the last job imports the generated manifests and image-info, updates the
+DB with these information, creates a branch, a commit, pushes it on Github and
+finally opens a PR using the [Schutzbot](https://github.com/schutzbot) user.
+
+The PR message contains a check list of changed manifests and image-info. The
+list is generated with the command `tool/update_tool report --github-markdown`.
 
 #### Resuming in a diagram
-
 
 ```mermaid
 flowchart LR
@@ -43,27 +44,28 @@ flowchart LR
         GH0[(Repo)]
         GH01[Pipeline]
         GH01 --> GH1
-        GH1 -.-> GH0
-        GH1{Run each distro and build image info}
-        GH01 --> GH2{integrate all the image info inside the commit}
+        GH1 -.- GH0
+        GH2 -.- GH0
+        GH3 -.- GH0
+        GH1{3. Generate manifests}
+        GH01 --> GH2{4. Build image-infos}
+        GH01 --> GH3{5. Create $BRANCH\n create update commit\npush $BRANH}
     end
-    subgraph Github
-        GH3[(R)]
+    subgraph Github/Manifest-db
+        RS0[ 2. Action\n\nTrigger\npeline\non main ]
+        RSO1[ 7. Action\n\n Propagate main's\nSHA on OSBuild]
+        GH4[(Repo)]
     end
-    subgraph Update DB Action
-        RS0((Action))
-        RS0 --> RS1
-        RS1((Clone\nOSBuild-Composer))
-        RS0 -. copy\nmanifests .-> RS2[(DB)]
-        RS0 --> RS3{Create branch\nand commit}
-        RS0 -- push branch --> GH0
+    subgraph Github/OSBuild
+        OS0[(Repo)]
     end
-
-    RS0 -- trigger\nPipeline --> GH01    
-    Maintainer -- starts github action--> RS0
-    GH2 -- Push to github\nand\ncreate a PR--> Github
-    Maintainer -- review PR --> GH3
-
+    RS0 --> GH01    
+    Maintainer -- 1. start github action--> RS0
+    GH3 == open PR ==> GH4
+    Maintainer --6. review to\nmerge/discard\nPR --> GH4
+    Maintainer --8. review to\nmerge/discard\nPR --> OS0
+    RSO1 == open PR ==> OS0
+    GH4 -. upon\nupdate\non main .-> RSO1
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ list is generated with the command `tool/update_tool report --github-markdown`.
 #### Resuming in a diagram
 
 ```mermaid
-flowchart LR
+flowchart TD
     subgraph Gitlab
         GH0[(Repo)]
         GH01[Pipeline]
@@ -48,11 +48,11 @@ flowchart LR
         GH2 -.- GH0
         GH3 -.- GH0
         GH1{3. Generate manifests}
-        GH01 --> GH2{4. Build image-infos}
-        GH01 --> GH3{5. Create $BRANCH\n create update commit\npush $BRANH}
+        GH01 --> GH2{4. Build all image-info}
+        GH01 --> GH3{5. Create $BRANCH\n create update commit\npush $BRANCH}
     end
     subgraph Github/Manifest-db
-        RS0[ 2. Action\n\nTrigger\npeline\non main ]
+        RS0[ 2. Action\n\nTrigger pipeline\non branch main ]
         RSO1[ 7. Action\n\n Propagate main's\nSHA on OSBuild]
         GH4[(Repo)]
     end
@@ -60,12 +60,13 @@ flowchart LR
         OS0[(Repo)]
     end
     RS0 --> GH01    
-    Maintainer -- 1. start github action--> RS0
-    GH3 == open PR ==> GH4
-    Maintainer --6. review to\nmerge/discard\nPR --> GH4
-    Maintainer --8. review to\nmerge/discard\nPR --> OS0
+    i((Scheduler)) -- 1. start github action--> RS0
+    GH3 == open PR ===> GH4
+    j{{Maintainer}} -.6. review to\nmerge/discard\nPR .-> GH4
+    j -..8. review to\nmerge/discard\nPR ..-> OS0
+
     RSO1 == open PR ==> OS0
-    GH4 -. upon\nupdate\non main .-> RSO1
+    GH4 ---|upon\nupdate\non main| RSO1
 ```
 
 

--- a/schutzbot/gen_manifests.sh
+++ b/schutzbot/gen_manifests.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+set -euxo pipefail
+
+git clone https://github.com/osbuild/osbuild-composer.git
+cd osbuild-composer
+echo "Installing build dependencies"
+sudo dnf install -y redhat-rpm-config
+sudo dnf config-manager --set-enabled codeready-builder-for-rhel-9-rhui-rpms
+sudo dnf build-dep -y osbuild-composer.spec
+echo "Generating manifests"
+go run ./cmd/gen-manifests -workers 50 -output ../manifests

--- a/schutzbot/include_image_info.sh
+++ b/schutzbot/include_image_info.sh
@@ -21,7 +21,7 @@ git config --local user.email "imagebuilder-bots+schutzbot@redhat.com"
 git remote add upstream https://schutzbot:"$SCHUTZBOT_GH_TOKEN"@github.com/schutzbot/manifest-db.git
 
 git add -A && \
-    git commit --amend -m "db: update
+    git commit -m "db: update
 
 Automatic update:
 - manifests from latest composer

--- a/schutzbot/include_image_info.sh
+++ b/schutzbot/include_image_info.sh
@@ -20,6 +20,8 @@ git config --local user.email "imagebuilder-bots+schutzbot@redhat.com"
 
 git remote add upstream https://schutzbot:"$SCHUTZBOT_GH_TOKEN"@github.com/schutzbot/manifest-db.git
 
+pip install columnify
+
 git add -A && \
     git commit -m "db: update
 
@@ -28,8 +30,8 @@ Automatic update:
 - image-info from pipeline $CI_PIPELINE_ID" && \
     git push --set-upstream upstream "$CI_COMMIT_BRANCH" && \
     gh pr create \
-        --title "db update" \
-        --body "automated db update" \
+        --title "db: automated update" \
+        --body "$(tools/update_tool report --github-markdown)" \
         --repo "osbuild/manifest-db" \
         -r lavocatt
 

--- a/schutzbot/include_image_info.sh
+++ b/schutzbot/include_image_info.sh
@@ -12,9 +12,6 @@ echo "${SCHUTZBOT_GH_TOKEN}" | gh auth login --with-token
 mv ci-details-before-run /tmp
 rm -rf generated-image-infos
 
-# Amend the commit containing the db update
-git checkout "$CI_COMMIT_BRANCH"
-
 git config --local user.name "SchutzBot"
 git config --local user.email "imagebuilder-bots+schutzbot@redhat.com"
 
@@ -22,13 +19,17 @@ git remote add upstream https://schutzbot:"$SCHUTZBOT_GH_TOKEN"@github.com/schut
 
 pip install columnify
 
+now=$(date '+%Y-%m-%d-%H%M%S')
+BRANCH_NAME="db-update-$now"
+
 git add -A && \
     git commit -m "db: update
+
 
 Automatic update:
 - manifests from latest composer
 - image-info from pipeline $CI_PIPELINE_ID" && \
-    git push --set-upstream upstream "$CI_COMMIT_BRANCH" && \
+    git push upstream "$BRANCH_NAME:$BRANCH_NAME" && \
     gh pr create \
         --title "db: automated update" \
         --body "$(tools/update_tool report --github-markdown)" \

--- a/tools/import-image-tests
+++ b/tools/import-image-tests
@@ -108,7 +108,7 @@ def parse_distro(ci_file: Union[str, pathlib.Path]) -> Dict[str, List[str]]:
     if ci_file:
         with open(ci_file, "r", encoding="utf-8") as f:
             data = yaml.load(f, Loader=yaml.Loader)
-            runners = data["Manifests"]["parallel"]["matrix"]
+            runners = data["Image-info-build"]["parallel"]["matrix"]
             for runner in runners:
                 for machine_id in runner["RUNNER"]:
                     flavor = machine_id.split("/")[-1]

--- a/tools/update_tool
+++ b/tools/update_tool
@@ -91,7 +91,7 @@ class GHReport(Report):
         print("Please review each DB entry")
 
     def row(self, name, mstatus, istatus):
-        print(name, end=": ")
+        print(f"- [ ] {name}", end=": ")
         print(f"manifest: {GHReport.status_map[mstatus]}{mstatus}", end=", ")
         print(f"image-info:{GHReport.status_map[istatus]}{istatus}.")
 


### PR DESCRIPTION
This pull request introduces:
- [x] manifest generation as a preliminary step during Gitlab CI before building the image-info. This removes the need of generating the manifests in osbuild-composer.
- [x] simplifictation of the  workflow to generate an update by only keeping in the trigger in the  Github action (before we were having copying happening there).
- [x] propagating the new version to OSBuild
- [x] running the two actions on a schedule