### PR TITLE
ci: add a second behavior for the trigger pipeline

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -84,7 +84,45 @@ Image-info-build:
     - tools/import-image-tests manifests manifest-db --manifest-only --db-ignore=db-ignore --filter-with-ci-distros=.gitlab-ci.yml --verbose
     - sudo test/cases/manifest_tests
   rules:
-    - if: '$CI_PIPELINE_SOURCE == "trigger"'
+    - if: $CI_PIPELINE_SOURCE == "trigger" && $TRIGGER_KIND == "default"
+  artifacts:
+    when: always
+    paths:
+      - generated-image-infos/
+  dependencies:
+    - Manifest-gen
+  parallel:
+    matrix:
+      - RUNNER:
+          - aws/fedora-35-x86_64
+          - aws/fedora-35-aarch64
+          - aws/fedora-36-x86_64
+          - aws/fedora-36-aarch64
+          - aws/centos-stream-8-x86_64
+          - aws/centos-stream-8-aarch64
+          - aws/centos-stream-9-x86_64
+          - aws/centos-stream-9-aarch64
+      - RUNNER:
+          - aws/rhel-8.6-ga-x86_64
+          - aws/rhel-8.6-ga-aarch64
+          - aws/rhel-8.7-nightly-x86_64
+          - aws/rhel-8.7-nightly-aarch64
+          - aws/rhel-9.0-ga-x86_64
+          - aws/rhel-9.0-ga-aarch64
+          - aws/rhel-9.1-nightly-x86_64
+          - aws/rhel-9.1-nightly-aarch64
+        INTERNAL_NETWORK: "true"
+
+Image-info-test:
+  stage: build
+  extends: .terraform
+  script:
+    - schutzbot/deploy.sh
+    - schutzbot/selinux-context.sh
+    - tools/import-image-tests manifests manifest-db --manifest-only --db-ignore=db-ignore --filter-with-ci-distros=.gitlab-ci.yml --verbose
+    - sudo test/cases/manifest_tests --test
+  rules:
+    - if: $CI_PIPELINE_SOURCE == "trigger" && $TRIGGER_KIND == "test"
   artifacts:
     when: always
     paths:
@@ -123,7 +161,7 @@ push-image-info:
   dependencies:
     - Manifest-gen
   rules:
-    - if: '$CI_PIPELINE_SOURCE == "trigger"'
+    - if: $CI_PIPELINE_SOURCE == "trigger" && $TRIGGER_KIND == "default"
   parallel:
     matrix:
       - RUNNER:

--- a/schutzbot/gen_manifests.sh
+++ b/schutzbot/gen_manifests.sh
@@ -9,3 +9,23 @@ sudo dnf config-manager --set-enabled codeready-builder-for-rhel-9-rhui-rpms
 sudo dnf build-dep -y osbuild-composer.spec
 echo "Generating manifests"
 go run ./cmd/gen-manifests -workers 50 -output ../manifests
+
+if [ "${COMPOSER_REMOTE:-}" ]; then
+    cd ..
+    mv manifests tmp
+    mkdir manifests
+    git clone ${COMPOSER_REMOTE} osbuild-composer2
+    cd osbuild-composer2
+    git checkout ${COMPOSER_BRANCH}
+    echo "Installing build dependencies"
+    sudo dnf build-dep -y osbuild-composer.spec
+    echo "Generating manifests"
+    go run ./cmd/gen-manifests -workers 50 -output ../manifests2
+    cd ..
+    echo "Keeping only the different ones"
+    cd manifests2
+    for f in *
+    do
+         diff ${f} ../tmp/${f} || mv ${f} ../manifests/${f}
+    done
+fi

--- a/test/cases/manifest_tests
+++ b/test/cases/manifest_tests
@@ -4,11 +4,21 @@ Starts the osbuild-image-test executable asking it to filter its tests based on
 current machine architecture and distribution.
 """
 
+import argparse
 import subprocess
 import configparser
 import platform
 import sys
 from subprocess import CalledProcessError
+
+parser = argparse.ArgumentParser(description="manifest tests")
+parser.add_argument(
+    "--test",
+    action="store_true",
+    default=False,
+    help="Test the generated image info against the DB, default to generator "
+    "mode"
+)
 
 OS_RELEASE_PATH = "/etc/os-release"
 
@@ -23,11 +33,14 @@ distro = distro.replace('.', '')
 print(f"Running the osbuild-image-test for arch {platform.machine()} and "
         f"distribution {distro}")
 
+args = parser.parse_args()
+
 try:
-    subprocess.run(["tools/osbuild-image-test",
+    command = ["tools/osbuild-image-test",
                     f"--arch={platform.machine()}",
-                    f"--distro={distro}",
-                    "--generator-mode"],
-                    check=True)
+                    f"--distro={distro}"]
+    if not args.test:
+        command.append("--generator-mode")
+    subprocess.run(command, check=True)
 except CalledProcessError:
     sys.exit(1)


### PR DESCRIPTION
The rewrite of the image definitions makes changes to the manifests but it shouldn't affect image info.
Every change there is non-functional. It would be great if we could trigger an image-info rebuild in such cases from the PR, before it's merged, to make sure nothing has changed.

To enable this kind of testing, this pull request adds another trigger pipeline to the suite.
The desired behavior is controlled by the `TRIGGER_KIND` variable.

With its value to `default` the trigger pipeline will perform the update scenario where it will build the manifest from composer's main branch and generate the image info in order to create a pull request.

With its value to `test` the trigger pipeline will run the checks from the manifests found in the branch given as a parameter and will:

- generate the manifests from composer's main
- generate the manifests from $`COMPOSER_REMOTE`'s $ `COMPOSER_BRANCH`
- only keep the ones that changed from the remote
- build the images
- test the image-info regarding the DB

To use it:

curl --request POST\
    --form token=$YOUR_TOKEN\
    --form ref=main\
    --form "variables[COMPOSER_REMOTE]=$SOME_REMOTE" \
    --form "variables[COMPOSER_BRANCH]=$SOME_BRANCH" \
    --form "variables[TRIGGER_KIND]=test" \
    https://gitlab.com/api/v4/projects/36844106/trigger/pipeline