### PR TITLE
ci: improve parallelisation

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -46,7 +46,7 @@ Regression:
   script:
     - schutzbot/deploy.sh
     - schutzbot/selinux-context.sh
-    - sudo test/cases/manifest_tests
+    - sudo test/cases/manifest_tests ${PARALLEL_EXEC}
   rules:
     - if: '$CI_PIPELINE_SOURCE != "trigger"'
   artifacts:
@@ -55,7 +55,8 @@ Regression:
       - generated-image-infos/
   parallel:
     matrix:
-      - RUNNER:
+      - PARALLEL_EXEC: ["1/4", "2/4", "3/4", "4/4"]
+        RUNNER:
           - aws/fedora-36-x86_64
           - aws/fedora-36-aarch64
           - aws/fedora-37-x86_64
@@ -64,7 +65,8 @@ Regression:
           - aws/centos-stream-8-aarch64
           - aws/centos-stream-9-x86_64
           - aws/centos-stream-9-aarch64
-      - RUNNER:
+      - PARALLEL_EXEC: ["1/4", "2/4", "3/4", "4/4"]
+        RUNNER:
           - aws/rhel-8.6-ga-x86_64
           - aws/rhel-8.6-ga-aarch64
           - aws/rhel-8.7-ga-x86_64
@@ -103,7 +105,7 @@ Image-info-build:
     - schutzbot/deploy.sh
     - schutzbot/selinux-context.sh
     - tools/import-image-tests manifests manifest-db --manifest-only --db-ignore=db-ignore --filter-with-ci-distros=.gitlab-ci.yml --verbose
-    - sudo test/cases/gen_db
+    - sudo test/cases/gen_db ${PARALLEL_EXEC}
   rules:
     - if: '$CI_PIPELINE_SOURCE == "trigger"'
   artifacts:
@@ -114,7 +116,8 @@ Image-info-build:
     - Manifest-gen
   parallel:
     matrix:
-      - RUNNER:
+      - PARALLEL_EXEC: ["1/4", "2/4", "3/4", "4/4"]
+        RUNNER:
           - aws/fedora-36-x86_64
           - aws/fedora-36-aarch64
           - aws/fedora-37-x86_64
@@ -123,7 +126,8 @@ Image-info-build:
           - aws/centos-stream-8-aarch64
           - aws/centos-stream-9-x86_64
           - aws/centos-stream-9-aarch64
-      - RUNNER:
+      - PARALLEL_EXEC: ["1/4", "2/4", "3/4", "4/4"]
+        RUNNER:
           - aws/rhel-8.6-ga-x86_64
           - aws/rhel-8.6-ga-aarch64
           - aws/rhel-8.7-ga-x86_64

--- a/test/cases/gen_db
+++ b/test/cases/gen_db
@@ -21,14 +21,23 @@ distro = distro.replace('"', '')
 distro = distro.replace('.', '')
 
 print(f"Running the osbuild-image-test for arch {platform.machine()} and "
-        f"distribution {distro}")
+      f"distribution {distro}")
 
+command = ["tools/osbuild-image-test",
+           f"--arch={platform.machine()}",
+           f"--distro={distro}",
+           "--generator-mode"]
+
+pa_exec = sys.argv[1] if len(sys.argv) > 1 else None
+if pa_exec:
+    total = int(pa_exec.split("/")[1])
+    part = int(pa_exec.split("/")[0])
+    command.append(f"--instance-number={part}")
+    command.append(f"--total-number-of-instances={total}")
+
+print(" ".join(command), flush=True)
 try:
-    subprocess.run(["tools/osbuild-image-test",
-                    f"--arch={platform.machine()}",
-                    f"--distro={distro}",
-                    "--generator-mode"],
-                    check=True)
+    subprocess.run(command, check=True)
 except CalledProcessError as e:
     print(e, file=sys.stderr)
     sys.exit(1)

--- a/test/cases/manifest_tests
+++ b/test/cases/manifest_tests
@@ -20,13 +20,23 @@ distro = f"{config.get('DEFAULT', 'ID')}-{config.get('DEFAULT', 'VERSION_ID')}"
 distro = distro.replace('"', '')
 distro = distro.replace('.', '')
 
-print(f"Running the osbuild-image-test for arch {platform.machine()} and "
-        f"distribution {distro}")
 
+print(f"Running the osbuild-image-test executable for arch {platform.machine()} and "
+      f"distribution {distro}")
+
+command = ["tools/osbuild-image-test",
+           f"--arch={platform.machine()}",
+           f"--distro={distro}"]
+
+pa_exec = sys.argv[1] if len(sys.argv) > 1 else None
+if pa_exec:
+    total = int(pa_exec.split("/")[1])
+    part = int(pa_exec.split("/")[0])
+    command.append(f"--instance-number={part}")
+    command.append(f"--total-number-of-instances={total}")
+
+print(" ".join(command), flush=True)
 try:
-    subprocess.run(["tools/osbuild-image-test",
-                    f"--arch={platform.machine()}",
-                    f"--distro={distro}"],
-                    check=True)
+    subprocess.run(command, check=True)
 except CalledProcessError:
     sys.exit(1)

--- a/tools/osbuild-image-test
+++ b/tools/osbuild-image-test
@@ -12,6 +12,7 @@ import subprocess
 import sys
 import traceback
 import shutil
+import math
 
 from collections import defaultdict
 from typing import Iterator, List, Optional, Dict
@@ -149,7 +150,6 @@ class TestCase:
     can compare the produced image-info from the reference one
     can dump the built image-info to disk
     """
-
 
     def __init__(self, path, data: Dict, osb: OSBuild, imi: ImageInfoExec) -> None:
         self.path = path
@@ -402,7 +402,21 @@ def run_tests_cases(args):
         print(f"{RED}FAIL{RESET}: no tests to run")
         success = False
 
-    for test in tests:
+    # compute the bucket of tests this instance is gonna run.
+    # by default, the bucket size is the entire test set and the bucket number
+    # is 0.
+    #
+    # If the user specified that more than one instances are sharing the tests
+    # set, then figure out which tests to execute based on the instance number
+    # over the total number of instances.
+    bucket_number: int = args.instance_number - 1
+    bucket_size: int = math.ceil(len(tests) / args.total_number_of_instances)
+
+    start_index: int = bucket_number * bucket_size
+    end_index: int = (bucket_number + 1) * bucket_size
+    end_index = min(end_index, len(tests))
+
+    for test in tests[start_index:end_index]:
         print(f"{test.id}", end=" ", flush=True)
         # Skip for dry run
         if args.dry_run:
@@ -539,6 +553,19 @@ def main():
         type=os.path.abspath,
         default="manifest-db",
         help="path to the database folder"
+    )
+    parser.add_argument(
+        "--instance-number",
+        type=int,
+        default=1,
+        help="if several identical instances are running, specify its number"
+        "here, numbering starts at 1"
+    )
+    parser.add_argument(
+        "--total-number-of-instances",
+        type=int,
+        default=1,
+        help="total number of identical instances working on the same input data"
     )
 
     args = parser.parse_args()


### PR DESCRIPTION
Run more than once the same arch/distro in parallel. Each instance will work on the other half of the test cases to run. All tests cases will be executed but twice as fast.