### PR TITLE
tools/image-info: Update Mount() signature.

### DIFF
--- a/tools/image-info
+++ b/tools/image-info
@@ -2678,13 +2678,20 @@ def append_partitions(report, image):
                 jsonschema.validate(options, info.get_schema()["properties"]["options"])
 
                 # Finally mount
-                mmgr.mount(mounts.Mount(
-                    part_device,
-                    info,
-                    devices_map[part_device],  # retrieves the associated Device Object
-                    part_mountpoint,
-                    options))
-
+                mnt_kwargs = {
+                    "name": part_device,
+                    "info": info,
+                    # retrieves the associated Device Object
+                    "device": devices_map[part_device],
+                    "target": part_mountpoint,
+                    "options": options,
+                }
+                # XXX: remove inspect and just add once osbuild PR#1501 is merged
+                import inspect
+                if "partition" in inspect.getfullargspec(mounts.Mount):
+                    # Just a filesystem, no partitions on this device
+                    mnt_kwargs["partition"] = None
+                mmgr.mount(mounts.Mount(**mnt_kwargs))
             if not root_tree:
                 raise RuntimeError("The root filesystem tree is not mounted")
 


### PR DESCRIPTION
This is needed for when https://github.com/osbuild/osbuild/pull/1501 merges. That PR adds the ability to mount partition device from a defined source rather than the source itself directly and the partition option to the function was added to allow requesting this behavior.