### PR TITLE
gen_manifests.sh: use images repo instead of osbuild-composer

### DIFF
--- a/schutzbot/gen_manifests.sh
+++ b/schutzbot/gen_manifests.sh
@@ -1,11 +1,11 @@
 #!/bin/bash
 set -euxo pipefail
 
-git clone https://github.com/osbuild/osbuild-composer.git
-cd osbuild-composer
+git clone https://github.com/osbuild/images.git
+cd images
 echo "Installing build dependencies"
 sudo dnf install -y redhat-rpm-config
 sudo dnf config-manager --set-enabled codeready-builder-for-rhel-9-rhui-rpms
-sudo dnf build-dep -y osbuild-composer.spec
+sudo dnf build-dep -y osbuild-composer
 echo "Generating manifests"
 go run ./cmd/gen-manifests -workers 50 -output ../manifests


### PR DESCRIPTION
Let's use the authoritative repo for image definitions to generate testing manifests, which is no longer the osbuild-composer repo. This will allow us to get rid of the testing manifests from the osbuild-composer repo, as well as any related tools.