### PR TITLE
Change cache directory for manifest gen

### DIFF
--- a/schutzbot/gen_manifests.sh
+++ b/schutzbot/gen_manifests.sh
@@ -7,4 +7,4 @@ echo "Installing build dependencies"
 sudo dnf install -y redhat-rpm-config btrfs-progs-devel device-mapper-devel
 sudo dnf build-dep -y osbuild-composer
 echo "Generating manifests"
-go run ./cmd/gen-manifests -workers 50 -output ../manifests
+go run ./cmd/gen-manifests -workers 50 -output ../manifests --cache /var/tmp/rpmmd


### PR DESCRIPTION
The fedora runner doesn't have enough space in /tmp as it's using tmpfs.