### PR TITLE
tools: add logmonitor on stderr by default

### DIFF
--- a/tools/osbuild-image-test
+++ b/tools/osbuild-image-test
@@ -60,6 +60,8 @@ class OSBuild:
             "--store", os.fspath(self.store),
             "--output-dir", os.fspath(self.outdir),
             "--json",
+            # improve visibility for real errors by logging to stderr
+            "--monitor=LogMonitor", "--monitor-fd=2",
         ]
 
         if args:


### PR DESCRIPTION
If a test fails there is little visiblity right now what exactly went wrong because the osbuild --json will default to a NullMontior.

This commit switches to a LogMontior on stderr so that if the test fails we get the full log of the operation.

This was useful to debug a failure in https://github.com/osbuild/osbuild/pull/1573