### PR TITLE
image-info: don't use readfp() on configparser

### DIFF
--- a/tools/image-info
+++ b/tools/image-info
@@ -2110,11 +2110,11 @@ def _read_inifile_to_dict(config_path):
     result = {}
 
     with contextlib.suppress(FileNotFoundError):
-        with open(config_path) as f:
+        with open(config_path, encoding="utf-8") as f:
             parser = configparser.RawConfigParser()
             # prevent conversion of the opion name to lowercase
             parser.optionxform = lambda option: option
-            parser.readfp(f)
+            parser.read_file(f)
 
             for section in parser.sections():
                 section_config = dict(parser.items(section))


### PR DESCRIPTION
Fix https://gitlab.com/redhat/services/products/image-builder/ci/manifest-db/-/jobs/7403518528#L2132